### PR TITLE
feat: add view schedule, help, and better search

### DIFF
--- a/data/todo.dat
+++ b/data/todo.dat
@@ -6,5 +6,6 @@ D | 0 | return book | 30/01/2022 11:00
 E | 0 | project meeting | 24/01/2022 21:30
 D | 1 | deliver rw function | 25/01/2022 14:00
 T | 1 | test new save
-T | 1 | Level-10
-T | 0 | movie booking
+E | 0 | read | 06/06/2022 00:00
+D | 0 | book | 06/06/2022 04:00
+T | 0 | 11 confirm movie booking with Adam

--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -34,7 +34,12 @@ public class Duke {
      * @return the response
      */
     public String getResponse(String input) {
-        Command cmd = Parser.parseCommand(input);
+        Command cmd = null;
+        try {
+            cmd = Parser.parseCommand(input);
+        } catch (DukeException e) {
+            ui.showError(e.getMessage());
+        }
 
         // ensures cmd is not null so that it can be executed
         assert cmd != null;

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -6,9 +6,11 @@ import duke.command.Command;
 import duke.command.DeleteCommand;
 import duke.command.ExitCommand;
 import duke.command.FindCommand;
+import duke.command.HelpCommand;
 import duke.command.InvalidCommand;
 import duke.command.ListCommand;
 import duke.command.ToggleCommand;
+import duke.command.ViewScheduleCommand;
 import duke.task.Deadline;
 import duke.task.Event;
 import duke.task.Task;
@@ -59,44 +61,36 @@ public class Parser {
      * @param fullCommand the full command containing the keyword and its necessary details
      * @return the corresponding command
      */
-    public static Command parseCommand(String fullCommand) {
+    public static Command parseCommand(String fullCommand) throws DukeException {
         // Not sure how to trim (if even necessary) this down since it's all case-checking.
-        Command cmd;
         String[] input = fullCommand.split(" ", 2);
-
-        //TODO: simplify this using hashset
 
         switch (input[0].toLowerCase()) {
         case "exit":
-            cmd = new ExitCommand();
-            break;
+            return new ExitCommand();
         case "list":
-            cmd = new ListCommand();
-            break;
+            return new ListCommand();
         case "mark":
         case "unmark":
-            cmd = new ToggleCommand(input[0], input[1]);
-            break;
+            return new ToggleCommand(input[0], input[1]);
         case "todo":
         case "event":
         case "deadline":
-            cmd = new AddCommand(input[0], input[1]);
-            break;
+            return new AddCommand(input[0], input[1]);
         case "remove":
         case "delete":
-            cmd = new DeleteCommand(input[1]);
-            break;
+            return new DeleteCommand(input[1]);
         case "clear":
-            cmd = new ClearCommand();
-            break;
+            return new ClearCommand();
         case "find":
-            cmd = new FindCommand(input[1]);
-            break;
+            return new FindCommand(input[1]);
+        case "view":
+            return new ViewScheduleCommand(input[1]);
+        case "help":
+            return new HelpCommand();
         default:
-            cmd = new InvalidCommand();
-            break;
+            return new InvalidCommand();
         }
-        return cmd;
     }
 
     /**

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -1,7 +1,11 @@
 package duke;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
+import duke.command.AddCommand;
+import duke.command.Command;
 import duke.task.Task;
 
 /**
@@ -77,36 +81,20 @@ public class Ui {
     }
 
     /**
-     * Show that the input task has been removed from the list.
-     *
-     * @param listSize the list size
-     * @param task     the task
-     * @return A string to acknowledge that a task has been removed from the list.
-     */
-    public String showDeletion(int listSize, Task task) {
-        StringBuilder sb = new StringBuilder();
-        String ack = "Noted, I've removed the following task: ";
-        String taskString = (listSize == 1) ? "task" : "tasks";
-        String size = String.format("Now you have %d %s in the list", listSize, taskString);
-
-        sb.append(STR_PADDING).append(ack).append("\n");;
-        sb.append(STR_PADDING).append("   ").append(task).append("\n");
-        sb.append(STR_PADDING).append(size);
-
-        return sb.toString();
-    }
-
-    /**
      * Show that the input task has been added to the list.
      *
      * @param listSize the list size
      * @param task     the task
      * @return A string to acknowledge that a task has been added to the list.
      */
-    public String showAddition(int listSize, Task task) {
+    public String showAdditionOrDeletion(Command command, int listSize, Task task) {
         StringBuilder sb = new StringBuilder();
-        String taskString = (listSize == 1) ? "task" : "tasks";
-        String ack = "Got it, I've added this task: ";
+        String taskString = (listSize == 1)
+                ? "task"
+                : "tasks";
+        String ack = (command instanceof AddCommand)
+                ? "Got it, I've added this task: "
+                : "Noted, I've removed the following task: ";
         String size = String.format("Now you have %d %s in the list", listSize, taskString);
 
         sb.append(STR_PADDING).append(ack).append("\n");
@@ -124,5 +112,91 @@ public class Ui {
      */
     public String showError(String errorMessage) {
         return String.format("Error: %s", errorMessage);
+    }
+
+    /**
+     * Shows a list of dated-events that occur on the specified date.
+     *
+     * @param dateCheck the date that the user wants to see
+     * @param filteredTask the taskList that has been filtered to search for the keyword
+     * @return the contents of filteredTask that matches the keyword, if any.
+     */
+    public String showSchedule(Date dateCheck, List<Task> filteredTask) {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+
+        if (filteredTask.isEmpty()) {
+            return String.format("I could not find any tasks that occurs on \"%s\"", sdf.format(dateCheck));
+        } else {
+            StringBuilder sb = new StringBuilder(Ui.STR_PADDING);
+            sb.append(String.format("You've searched for task(s) that occur on: \"%s\"\n", sdf.format(dateCheck)));
+            sb.append(Ui.STR_PADDING + "Here are the matching tasks in your list:");
+            for (int i = 0; i < filteredTask.size(); i++) {
+                sb.append(String.format("\n" + Ui.STR_PADDING + "  %d. " + filteredTask.get(i), i + 1));
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Shows a list of commands that the user can use.
+     * @return list of commands that the user can use
+     */
+    public String showHelp() {
+        return "Here are the available commands -- \n"
+                + showHelpAdd()
+                + showHelpClear()
+                + showHelpDelete()
+                + showHelpExit()
+                + showHelpFind()
+                + showHelpList()
+                + showHelpToggle()
+                + showHelpView();
+    }
+
+    private String showHelpAdd() {
+        return "Add command: \n"
+                + "  todo <description>\n"
+                + "  event <description> /at <dd/MM/yyyy hh:mm>\n"
+                + "  deadline <description> /by <dd/MM/yyyy hh:mm>\n"
+                + "E.g: event meet John at the Cafe /at 06/03/2022 16:00\n\n";
+    }
+
+    private String showHelpClear() {
+        return "Clear command: [WARNING] This will remove all your tasks!!\n"
+                + "  clear\n\n";
+    }
+
+    private String showHelpDelete() {
+        return "Delete command: [NOTE] you can see the entry number using `list`\n"
+                + "  delete <entry number>\n\n";
+    }
+
+    private String showHelpExit() {
+        return "Exit command: [NOTE] Close using this to ensure your data is saved!!\n"
+                + "  exit\n\n";
+    }
+
+    private String showHelpFind() {
+        return "Find command:\n"
+                + "  find <keyword>\n"
+                + "E.g: find book -- this would give you all the task that contains "
+                + "\t\"book\" such as \"books\" or \"booking\"\n\n";
+    }
+
+    private String showHelpList() {
+        return "List command: [NOTE] the entry numbers here are used in mark/unmark/delete\n"
+                + "  list\n\n";
+    }
+
+    private String showHelpToggle() {
+        return "Mark/Unmark command: \n"
+                + "  mark <entry number>\n"
+                + "  unmark <entry number>\n\n";
+    }
+
+    private String showHelpView() {
+        return "View command: \n"
+                + "  view <dd/mm/yyyy>\n"
+                + "E.g: view 06/06/2022\n";
     }
 }

--- a/src/main/java/duke/command/AddCommand.java
+++ b/src/main/java/duke/command/AddCommand.java
@@ -41,12 +41,12 @@ public class AddCommand extends Command {
         switch (taskType) {
         case "todo":
             tasks.addTask(task = new ToDo(taskDetails));
-            return ui.showAddition(tasks.size(), task);
+            return ui.showAdditionOrDeletion(this, tasks.size(), task);
         case "event":
             String[] eventDetails = taskDetails.split(" /at ", 2);
             try {
                 tasks.addTask(task = new Event(eventDetails[0], eventDetails[1]));
-                return ui.showAddition(tasks.size(), task);
+                return ui.showAdditionOrDeletion(this, tasks.size(), task);
             } catch (DukeException e) {
                 return ui.showError(e.getMessage());
             }
@@ -54,7 +54,7 @@ public class AddCommand extends Command {
             String[] deadlineDetails = taskDetails.split(" /by ", 2);
             try {
                 tasks.addTask(task = new Deadline(deadlineDetails[0], deadlineDetails[1]));
-                return ui.showAddition(tasks.size(), task);
+                return ui.showAdditionOrDeletion(this, tasks.size(), task);
             } catch (DukeException e) {
                 return ui.showError(e.getMessage());
             }

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -41,7 +41,7 @@ public class DeleteCommand extends Command {
             if (deletionIndex < 0 || deletionIndex >= tasks.size()) {
                 return ui.showError("Invalid entry number!");
             } else {
-                return ui.showDeletion(tasks.size(), tasks.removeTask(deletionIndex));
+                return ui.showAdditionOrDeletion(this, tasks.size(), tasks.removeTask(deletionIndex));
             }
         } catch (DukeException e) {
             return ui.showError(e.getMessage());

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -25,12 +25,12 @@ public class FindCommand extends Command {
     }
 
     /**
-     * Execute.
+     * Displays a list of events that match the keyword given by the user.
      *
      * @param tasks   the tasks in `TaskList`
      * @param ui      the UI that the user interacts with
      * @param storage the storage that is used to read/write to the local file
-     * @return string to show whether the keyword has been found or if the list is empty.
+     * @return list of events that match the keyword given by the user, if any
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {

--- a/src/main/java/duke/command/HelpCommand.java
+++ b/src/main/java/duke/command/HelpCommand.java
@@ -1,0 +1,15 @@
+package duke.command;
+
+import duke.Storage;
+import duke.TaskList;
+import duke.Ui;
+
+/**
+ * An instance of HelpCommand
+ */
+public class HelpCommand extends Command {
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        return ui.showHelp();
+    }
+}

--- a/src/main/java/duke/command/InvalidCommand.java
+++ b/src/main/java/duke/command/InvalidCommand.java
@@ -19,6 +19,6 @@ public class InvalidCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
-        return "Invalid command.";
+        return "Invalid command. Try `help` to view the list of possible commands.";
     }
 }

--- a/src/main/java/duke/command/ViewScheduleCommand.java
+++ b/src/main/java/duke/command/ViewScheduleCommand.java
@@ -1,0 +1,70 @@
+package duke.command;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import duke.DukeException;
+import duke.Storage;
+import duke.TaskList;
+import duke.Ui;
+import duke.task.Deadline;
+import duke.task.Event;
+import duke.task.Task;
+
+/**
+ * An instance of ViewScheduleCommand.
+ */
+public class ViewScheduleCommand extends Command {
+
+    private final Date dateCheck;
+
+    /**
+     * Instantiates a new View schedule command.
+     *
+     * @param dateString the date string
+     */
+    public ViewScheduleCommand(String dateString) throws DukeException {
+        try {
+            this.dateCheck = new SimpleDateFormat("dd/MM/yyyy").parse(dateString);
+        } catch (ParseException e) {
+            throw new DukeException("Please enter the date in \"dd/MM/yyyy\" format\"");
+        }
+    }
+
+    /**
+     * Displays a list of events that match the date given by the user.
+     *
+     * @param tasks   the tasks in `TaskList`
+     * @param ui      the UI that the user interacts with
+     * @param storage the storage that is used to read/write to the local file
+     * @return list of events that match the date given by the user, if any
+     */
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        List<Task> filteredTask = tasks.getTasks().stream()
+                .filter(this::isDatedTask)
+                .filter(task -> isSameDate(getDate(task)))
+                .collect(Collectors.toList());
+
+        return ui.showSchedule(dateCheck, filteredTask);
+    }
+
+    private Date getDate(Task datedTask) {
+        return (datedTask instanceof Event)
+                ? ((Event) datedTask).getDate()
+                : ((Deadline) datedTask).getDate();
+    }
+
+    private boolean isSameDate(Date current) {
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        return sdf.format(current).equals(sdf.format(dateCheck));
+    }
+
+    private boolean isDatedTask(Task task) {
+        return task instanceof Event
+                || task instanceof Deadline;
+    }
+}

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -9,19 +9,19 @@ import duke.DukeException;
 public class Deadline extends Task {
 
     /** The `Date` of when this `Deadline` is held. */
-    private final Date by;
+    private final Date date;
 
     /**
      * Instantiates a new Deadline.
      *
      * @param taskName the task name/description
-     * @param by       the date of when this `Deadline` is due
+     * @param date       the date of when this `Deadline` is due
      * @throws DukeException if the `String` representation of the date does not follow the format
      */
-    public Deadline(String taskName, String by) throws DukeException {
+    public Deadline(String taskName, String date) throws DukeException {
         super(taskName);
         try {
-            this.by = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(by);
+            this.date = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(date);
         } catch (ParseException e) {
             throw new DukeException("Please enter the date in \"dd / MM / yyyy HH:mm\" format");
         }
@@ -31,18 +31,22 @@ public class Deadline extends Task {
      * Instantiates a new Deadline.
      *
      * @param taskName the task name/description
-     * @param by       the date of when this `Deadline` is due
+     * @param date       the date of when this `Deadline` is due
      * @param isMarked the is `Deadline` has been marked/completed
      * @throws DukeException if the `String` representation of the date does not follow the format
      */
-    public Deadline(String taskName, String by, String isMarked) throws DukeException {
+    public Deadline(String taskName, String date, String isMarked) throws DukeException {
         super(taskName);
         try {
-            this.by = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(by);
+            this.date = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(date);
             this.isMarked = (isMarked.equals("1"));
         } catch (ParseException e) {
-            throw new DukeException("Please enter the date in \"dd / MM / yyyy HH:mm\" format");
+            throw new DukeException("Please enter the date in \"dd/MM/yyyy HH:mm\" format");
         }
+    }
+
+    public Date getDate() {
+        return date;
     }
 
     /**
@@ -53,7 +57,7 @@ public class Deadline extends Task {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy @ hh:mm a");
-        return String.format("[D]%s (by: %s)", super.toString(), sdf.format(this.by));
+        return String.format("[D]%s (by: %s)", super.toString(), sdf.format(this.date));
     }
 
     /**
@@ -64,6 +68,6 @@ public class Deadline extends Task {
     public String toFile() {
         String markStatus = super.isMarked ? "1" : "0";
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        return String.format("%s | %s | %s | %s\n", "D", markStatus, super.taskName, sdf.format(this.by));
+        return String.format("%s | %s | %s | %s\n", "D", markStatus, super.taskName, sdf.format(this.date));
     }
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -9,21 +9,21 @@ import duke.DukeException;
 public class Event extends Task {
 
     /** The `Date` of when this `Event` is held. */
-    private final Date at;
+    private final Date date;
 
     /**
      * Instantiates a new Event.
      *
      * @param taskName the task name/description
-     * @param at       the date of when this `Event` is held
+     * @param date       the date of when this `Event` is held
      * @throws DukeException if the `String` representation of the date does not follow the format
      */
-    public Event(String taskName, String at) throws DukeException {
+    public Event(String taskName, String date) throws DukeException {
         super(taskName);
         try {
-            this.at = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(at);
+            this.date = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(date);
         } catch (ParseException e) {
-            throw new DukeException("Please enter the date in \"dd / MM / yyyy HH:mm\" format");
+            throw new DukeException("Please enter the date in \"dd/MM/yyyy HH:mm\" format");
         }
     }
 
@@ -31,18 +31,22 @@ public class Event extends Task {
      * Instantiates a new Event.
      *
      * @param taskName the task name/description
-     * @param at       the date of when this `Event` is held
+     * @param date       the date of when this `Event` is held
      * @param isMarked the is `Event` has been marked/completed
      * @throws DukeException if the `String` representation of the date does not follow the format
      */
-    public Event(String taskName, String at, String isMarked) throws DukeException {
+    public Event(String taskName, String date, String isMarked) throws DukeException {
         super(taskName);
         try {
-            this.at = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(at);
+            this.date = new SimpleDateFormat("dd/MM/yyyy HH:mm").parse(date);
             this.isMarked = (isMarked.equals("1"));
         } catch (ParseException e) {
             throw new DukeException("Please enter the date in \"dd / MM / yyyy HH:mm\" format");
         }
+    }
+
+    public Date getDate() {
+        return date;
     }
 
     /**
@@ -53,7 +57,7 @@ public class Event extends Task {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy @ hh:mm a");
-        return String.format("[E]%s (at: %s)", super.toString(), sdf.format(this.at));
+        return String.format("[E]%s (at: %s)", super.toString(), sdf.format(this.date));
     }
 
     /**
@@ -64,6 +68,6 @@ public class Event extends Task {
     public String toFile() {
         String markStatus = super.isMarked ? "1" : "0";
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        return String.format("%s | %s | %s | %s\n", "E", markStatus, super.taskName, sdf.format(this.at));
+        return String.format("%s | %s | %s | %s\n", "E", markStatus, super.taskName, sdf.format(this.date));
     }
 }

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -36,7 +36,7 @@ public class ParserTest {
      * Test to determine if {@link Parser#parseCommand(String)} works as intended.
      */
     @Test
-    public void parseCommandTest() {
+    public void parseCommandTest() throws DukeException {
         String[] commands = {
             "exit", "list", "mark 0", "unmark 0", "todo todo",
             "event e /at 29/01/2022 16:00", "deadline d /by 29/01/2022 16:00",


### PR DESCRIPTION
Implement:
1. [`B-ViewSchedules`](https://nus-cs2103-ay2122s2.github.io/website/se-book-adapted/projectDuke/index.html#b-viewschedules) -- users can now search dated events based on the dates by using `view <dd/MM/YYYY>`
2. [`C-Help`](https://nus-cs2103-ay2122s2.github.io/website/se-book-adapted/projectDuke/index.html#c-help) -- unintentionally added a help function without before realising that it was part of C
3. [`C-BetterSearch`](https://nus-cs2103-ay2122s2.github.io/website/se-book-adapted/projectDuke/index.html#c-bettersearch) -- This was already implemented in [this commit](https://github.com/yusufaine/ip/commit/3336e8403480cc6e4edcd29075f81b1c1560decd) and was [released in v0.1.1](https://github.com/yusufaine/ip/releases/tag/Level-9)